### PR TITLE
Fix for updating users with existing emails.

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -16,6 +16,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
 use Inertia\Inertia;
 use Inertia\Response;
 use Maatwebsite\Excel\Facades\Excel;
@@ -75,9 +76,9 @@ class UserController extends Controller
     public function store(Request $request): RedirectResponse
     {
         $request->validate([
-            'first_name' => 'required|string|max:255',
-            'last_name' => 'required|string|max:255',
-            'email' => 'required|string|lowercase|email|max:255|unique:' . User::class,
+            'first_name' => 'required|string|max:50',
+            'last_name' => 'required|string|max:50',
+            'email' => 'required|string|lowercase|email|max:60|unique:' . User::class,
             'laboratory' => 'required',
             'selectedRole' => 'required|exists:roles,id',
         ]);
@@ -136,12 +137,12 @@ class UserController extends Controller
     public function update(Request $request, User $user): RedirectResponse
     {
         $data = $request->validate([
-            'first_name' => 'required',
-            'last_name' => 'required',
-            'email' => 'required',
-            'laboratory' => 'required|integer',
+            'first_name' => ['required','string','max:50'],
+            'last_name' => ['required','string','max:50'],
+            'email' => ['required','string','lowercase','email','max:60',Rule::unique('users')->ignore($user->id)],
+            'laboratory' => ['required','integer','exists:laboratories,id'],
             'role' => 'required|exists:roles,id',
-            'updated_by' => 'required'
+            'updated_by' => ['required']
         ]);
         $user->roles()->detach();
         $user->assignRole(Role::findById($data['role'])->name);

--- a/lang/lt/validation.php
+++ b/lang/lt/validation.php
@@ -153,7 +153,7 @@ return [
     'starts_with' => 'The :attribute field must start with one of the following: :values.',
     'string' => 'The :attribute field must be a string.',
     'timezone' => 'The :attribute field must be a valid timezone.',
-    'unique' => 'The :attribute has already been taken.',
+    'unique' => 'Šis :attribute jau užimtas.',
     'uploaded' => 'The :attribute failed to upload.',
     'uppercase' => ':Attribute turi būti didžiosimis raidėmis.',
     'url' => 'The :attribute field must be a valid URL.',


### PR DESCRIPTION
Quick fix so that when editing users it correctly checks if the email is unique or not.
Reduced the max hit for first, last name and email, for names it's 50, for the email it's 60.