### PR TITLE
Telemetry and laboratory changes

### DIFF
--- a/app/Events/AmountRunningLow.php
+++ b/app/Events/AmountRunningLow.php
@@ -16,17 +16,14 @@ class AmountRunningLow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
     public InventoryItem $inventoryItem;
-    public bool $readerOrigin;
 
     /**
      * Create a new event instance.
      * @param InventoryItem $inventoryItem
-     * @param bool $readerOrigin
      */
-    public function __construct(InventoryItem $inventoryItem, bool $readerOrigin)
+    public function __construct(InventoryItem $inventoryItem)
     {
         $this->inventoryItem = $inventoryItem;
-        $this->readerOrigin = $readerOrigin;
     }
 
     /**

--- a/app/Exports/InventoryExports.php
+++ b/app/Exports/InventoryExports.php
@@ -51,13 +51,17 @@ class InventoryExports implements FromCollection, WithMapping, WithHeadings, Wit
                 $query->where('inventory_type', '=', $this->data['inventory_type']);
             }
             if (isset($this->data['laboratory'])) {
-                $query->whereHas('belongsToLaboratory', function ($query) {
-                    if (gettype($this->data['laboratory']) === "integer"){
-                        $query->where('id', '=', $this->data['laboratory']);
-                    } else {
-                        $query->where('name', 'like', '%' . $this->data['laboratory'] . '%');
-                    }
-                });
+                if (is_array($this->data['laboratory'])) {
+                    $query->whereIn('laboratory', $this->data['laboratory']);
+                } else {
+                    $query->whereHas('belongsToLaboratory', function ($query) {
+                        if (gettype($this->data['laboratory']) === "integer"){
+                            $query->where('id', '=', $this->data['laboratory']);
+                        } else {
+                            $query->where('name', 'like', '%' . $this->data['laboratory'] . '%');
+                        }
+                    });
+                }
             }
             if (isset($this->data['updated_by'])) {
                 $query->whereHas('updatedBy', function ($query) {

--- a/app/Exports/UserExports.php
+++ b/app/Exports/UserExports.php
@@ -2,7 +2,6 @@
 
 namespace App\Exports;
 
-use App\Models\Laboratory;
 use App\Models\User;
 use DateTimeZone;
 use Illuminate\Support\Collection;
@@ -30,7 +29,7 @@ class UserExports implements FromCollection, WithMapping, WithHeadings, WithStyl
      */
     public function collection(): Collection
     {
-        $query = User::query();
+        $query = User::query()->with('laboratories')->where('email', '!=', User::SYSTEM_EMAIL);
         if (!empty($this->data)) {
             if (isset($this->data['email'])) {
                 $query->where('email', 'like', '%' . $this->data['email'] . '%');
@@ -49,7 +48,7 @@ class UserExports implements FromCollection, WithMapping, WithHeadings, WithStyl
             $row->first_name,
             $row->last_name,
             $row->email,
-            $row->laboratory ? Laboratory::where('id', $row->laboratory)->first()->name : '-',
+            $row->laboratories->isNotEmpty() ? $row->laboratories->pluck('name')->implode('|') : '-',
             $row->created_at->setTimezone(new DateTimeZone('Europe/Vilnius'))->format('Y-m-d H:i:s'),
         ];
     }

--- a/app/Http/Controllers/InventoryItemController.php
+++ b/app/Http/Controllers/InventoryItemController.php
@@ -91,7 +91,7 @@ class InventoryItemController extends Controller
 
     public function userOwnInventory(): Response
     {
-        $query = InventoryItem::query()->where('laboratory', auth()->user()->laboratory);
+        $query = InventoryItem::query()->whereIn('laboratory', auth()->user()->laboratories()->pluck('laboratories.id'));
         $sortField = request("sort_field", 'updated_at');
         $sortDirection = request("sort_direction", 'desc');
 
@@ -313,6 +313,9 @@ class InventoryItemController extends Controller
         if (request('urlForReader')) { $redirectToReader = true; }
         $laboratories = Laboratory::query()->whereNotIn('id',[$inventoryItem->laboratory])->get();
         $itemTypes = ItemType::query()->get();
+        $can = [
+            'edit' => $request->user()->can('edit', $inventoryItem),
+        ];
         if ($inventoryItem->itemType->change_acc_amount) {
             return Inertia::render('User/Edit', [
                 'inventoryItem' => new CRUDInventoryItemResource($inventoryItem),
@@ -321,6 +324,7 @@ class InventoryItemController extends Controller
                 'redirectToReader' => $redirectToReader,
                 'queryParams' => $queryParams,
                 'referrer' => $request->query('referrer'),
+                'can' => $can,
             ]);
         } else {
             $amountLogs = $inventoryItem->amountLogs;
@@ -334,6 +338,7 @@ class InventoryItemController extends Controller
                 'redirectToReader' => $redirectToReader,
                 'queryParams' => $queryParams,
                 'referrer' => $request->query('referrer'),
+                'can' => $can,
             ]);
         }
     }
@@ -426,6 +431,9 @@ class InventoryItemController extends Controller
             'referrer' => $request->query('referrer'),
             'cupboardOptions' => $configurations['cupboardOptions'],
             'shelfOptions' => $configurations['shelfOptions'],
+            'can' => [
+                'edit' => $request->user()->can('edit', $inventoryItem),
+            ],
         ]);
     }
 
@@ -453,7 +461,7 @@ class InventoryItemController extends Controller
     {
         $validateData = $exportRequest->validated();
         if (str_ends_with($exportRequest->url(),'myLaboratory')) {
-            $validateData['laboratory'] = auth()->user()->laboratory;
+            $validateData['laboratory'] = auth()->user()->laboratories()->pluck('laboratories.id')->all();
         }
         $dateTimeNow = Carbon::now('Europe/Vilnius')->toDateTimeString();
         return Excel::download(new InventoryExports($validateData), $dateTimeNow . '_inventory_export.xlsx');

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -34,7 +34,7 @@ class UserController extends Controller
     public function index(): Response
     {
         Gate::authorize('viewAny', User::class);
-        $query = User::query();
+        $query = User::query()->where('email', '!=', User::SYSTEM_EMAIL);
         $sortField = request("sort_field", 'created_at');
         $sortDirection = request("sort_direction", 'desc');
         if (request('email')) {
@@ -87,11 +87,16 @@ class UserController extends Controller
     {
         Gate::authorize('store', User::class);
         $password = Str::random(10);
-        $request['is_disabled'] = false;
-        $request['locale'] = env('APP_LOCALE');
-        $request['password'] = Hash::make($password);
-        $request['name'] = $request['first_name'] . ' ' . $request['last_name'];
-        $newUser = User::create($request->all())->assignRole(Role::findById($request['selectedRole'])->name);
+        $data = $request->all();
+        $laboratoryIds = $data['laboratories'];
+        unset($data['laboratories']);
+        $data['is_disabled'] = false;
+        $data['locale'] = env('APP_LOCALE');
+        $data['password'] = Hash::make($password);
+        $data['name'] = $data['first_name'] . ' ' . $data['last_name'];
+        $newUser = User::create($data)->assignRole(Role::findById($request['selectedRole'])->name);
+        $newUser->laboratories()->sync($laboratoryIds);
+        $newUser->syncFacilitiesFromLaboratories();
         $newUser->email_verified_at = now();
         $newUser->save();
         event(new UserCreated($newUser, $password));
@@ -107,7 +112,7 @@ class UserController extends Controller
     {
         $roles = Role::query()->get();
         $roleName = $user->roles()->select('id')->get()->toArray();
-        $laboratories = Laboratory::all()->toArray();
+        $laboratories = Laboratory::query()->get();
         $facilities = $user->facilities->map(function ($facility) {
                                                 return [
                                                     'value' => $facility->id,
@@ -118,7 +123,7 @@ class UserController extends Controller
             'user' => new UserResource($user),
             'userRole' => $roleName ? $roleName[0]['id'] : '',
             'roles' => RolesForSelect::collection($roles),
-            'laboratories' => $laboratories,
+            'laboratories' => LaboratoriesForSelect::collection($laboratories),
             'facilities' => $facilities,
         ]);
     }
@@ -133,7 +138,6 @@ class UserController extends Controller
         Gate::authorize('edit',$user);
         $roles = Role::query()->get();
         $roleName = $user->roles()->select('id')->get()->toArray();
-        $laboratories = Laboratory::all()->select('id', 'name')->toArray();
         $labsForFacs = Laboratory::query()->get();
         $facilities = [];
 
@@ -151,7 +155,7 @@ class UserController extends Controller
             'user' => new UserResource($user),
             'userRole' => $roleName ? $roleName[0]['id'] : '',
             'roles' => RolesForSelect::collection($roles),
-            'laboratories' => $laboratories,
+            'laboratories' => LaboratoriesForSelect::collection($labsForFacs),
             'facilities' => $facilities,
             'failure' => session('failure'),
             'can' => [
@@ -176,8 +180,15 @@ class UserController extends Controller
             $user->syncRoles(Role::findById($request['role'])->name);
         }
         $roleChanged = $currentUserRole == $user->currentlyAssignedRole();
-        $user->update($request->validated());
-        if ($user->wasChanged() || !$roleChanged) {
+        $data = $request->validated();
+        $laboratoryIds = $data['laboratories'];
+        unset($data['laboratories']);
+        $oldLaboratoryIds = $user->laboratories->pluck('id')->sort()->values()->all();
+        $user->update($data);
+        $user->laboratories()->sync($laboratoryIds);
+        $user->syncFacilitiesFromLaboratories();
+        $laboratoriesChanged = $oldLaboratoryIds !== collect($laboratoryIds)->sort()->values()->all();
+        if ($user->wasChanged() || $laboratoriesChanged || !$roleChanged) {
             return Redirect::route('users.index')->with('success', __('actions.user.updated', ['email' => $user->email]));
         }
         return Redirect::route('users.index');
@@ -192,7 +203,10 @@ class UserController extends Controller
     {
         $user = User::findOrFail($id);
         Gate::authorize('delete',$user);
-        $userCount = User::query()->count();
+        if ($user->email === User::SYSTEM_EMAIL) {
+            return to_route('users.edit',$user)->with('failure',__('actions.user.noUsersLeft'));
+        }
+        $userCount = User::query()->where('email', '!=', User::SYSTEM_EMAIL)->count();
         if ($user->hasRole('super-admin')){
             Gate::authorize('delete',$user);
         }

--- a/app/Http/Requests/StoreRequests/StoreUserRequest.php
+++ b/app/Http/Requests/StoreRequests/StoreUserRequest.php
@@ -42,7 +42,8 @@ class StoreUserRequest extends FormRequest
             'first_name' => ['required','string','max:50'],
             'last_name' => ['required','string','max:50'],
             'email' => ['required','string','lowercase','email','max:60',Rule::unique('users')->whereNull('deleted_at')],
-            'laboratory' => 'required',
+            'laboratories' => ['required', 'array', 'min:1'],
+            'laboratories.*' => ['integer', 'exists:laboratories,id'],
             'selectedRole' => 'required|exists:roles,id',
         ];
     }

--- a/app/Http/Requests/UpdateRequests/UpdateUserRequest.php
+++ b/app/Http/Requests/UpdateRequests/UpdateUserRequest.php
@@ -57,7 +57,8 @@ class UpdateUserRequest extends FormRequest
             'first_name' => ['required','string','max:50'],
             'last_name' => ['required','string','max:50'],
             'email' => ['required','string','lowercase','email','max:60',Rule::unique('users')->ignore($userId)->whereNull('deleted_at')],
-            'laboratory' => ['required','integer','exists:laboratories,id'],
+            'laboratories' => ['required', 'array', 'min:1'],
+            'laboratories.*' => ['integer', 'exists:laboratories,id'],
             'role' => 'required|exists:roles,id',
             'updated_by' => ['required']
         ];

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -12,7 +12,6 @@ use Illuminate\Http\Resources\Json\JsonResource;
  * @property string $first_name
  * @property string $last_name
  * @property string $email
- * @property int $laboratory
  * @property boolean $is_disabled
  * @property BelongsTo $createdBy
  */
@@ -30,7 +29,7 @@ class UserResource extends JsonResource
             'first_name' => $this->first_name,
             'last_name' => $this->last_name,
             'email' => $this->email,
-            'laboratory' => $this->laboratory,
+            'laboratories' => $this->laboratories->pluck('id')->all(),
             'facilities' => $this->facilities->pluck('id')->all(),
             'is_disabled' => $this->is_disabled,
             'created_by' => $this->createdBy->email

--- a/app/Imports/GenericImport.php
+++ b/app/Imports/GenericImport.php
@@ -172,6 +172,10 @@ class GenericImport implements ToCollection, WithHeadingRow
             foreach ($manyToManyCollection as $relation => $relatedIds){
                 $updatedOrCreatedModel->$relation()->sync($relatedIds);
             }
+
+            if (method_exists($updatedOrCreatedModel, 'syncFacilitiesFromLaboratories')) {
+                $updatedOrCreatedModel->syncFacilitiesFromLaboratories();
+            }
             
         }
 

--- a/app/Jobs/NotifyFailedImports.php
+++ b/app/Jobs/NotifyFailedImports.php
@@ -10,12 +10,16 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
 use Maatwebsite\Excel\Facades\Excel;
 use Illuminate\Support\Facades\Mail;
+use Throwable;
 
 class NotifyFailedImports implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
 
     public array $failures;
     public User $user;
@@ -26,11 +30,33 @@ class NotifyFailedImports implements ShouldQueue
         $this->user = $user;
     }
 
+    /**
+     * Seconds to wait before each retry: 1 minute, then 5, then 15.
+     *
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return [60, 300, 900];
+    }
+
     public function handle(): void
     {
         $failFileName = 'failed-imports-' . now()->timestamp . '.xlsx';
         Excel::store(new FailedExports($this->failures, $this->user->locale), "temp/{$failFileName}");
         $path = storage_path("app/temp/{$failFileName}");
         Mail::to($this->user)->send(new ImportReportMail(__('mail.generic_import'), $path, $this->user));
+    }
+
+    /**
+     * Handle a job failure.
+     */
+    public function failed(Throwable $exception): void
+    {
+        Log::error('Failed to send failed-import report email', [
+            'user_id' => $this->user->id,
+            'email' => $this->user->email,
+            'exception' => $exception->getMessage(),
+        ]);
     }
 }

--- a/app/Jobs/RunImportJob.php
+++ b/app/Jobs/RunImportJob.php
@@ -17,6 +17,12 @@ class RunImportJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    /**
+     * Imports use updateOrCreate per row but aren't fully idempotent (duplicate
+     * audit records, duplicate success/failure emails), so retries are disabled.
+     */
+    public int $tries = 1;
+
     public ImportRun $importRun;
     public User $user;
 
@@ -67,5 +73,23 @@ class RunImportJob implements ShouldQueue
     public function displayName()
     {
         return "Import job (Definition ID: [{$this->importRun->definition->name}], Run By: User [{$this->user->email}])";
+    }
+
+    /**
+     * Handle a job failure. The internal try/catch in handle() already covers
+     * import-logic failures; this is a safety net for anything that escapes it
+     * (e.g. the importRun->update() calls themselves failing).
+     */
+    public function failed(\Throwable $exception): void
+    {
+        Log::error('Import job failed outside the expected error handling', [
+            'import_run_id' => $this->importRun->id,
+            'error' => $exception->getMessage(),
+        ]);
+
+        $this->importRun->update([
+            'status' => 'failed',
+            'finished_at' => now(),
+        ]);
     }
 }

--- a/app/Listeners/InventoryItemAmountCritical.php
+++ b/app/Listeners/InventoryItemAmountCritical.php
@@ -7,10 +7,24 @@ use App\Events\AmountRunningLow;
 use App\Mail\InventoryItemCriticalAmountReached;
 use App\Models\User;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
+use Throwable;
 
 class InventoryItemAmountCritical implements ShouldQueue
 {
+    public int $tries = 3;
+
+    /**
+     * Seconds to wait before each retry: 1 minute, then 5, then 15.
+     *
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return [60, 300, 900];
+    }
+
     /**
      * Handle the event.
      */
@@ -21,5 +35,17 @@ class InventoryItemAmountCritical implements ShouldQueue
         foreach ($recipients as $recipient) {
             Mail::to($recipient->email)->queue(new InventoryItemCriticalAmountReached($event->inventoryItem, $recipient));
         }
+    }
+
+    /**
+     * Handle a job failure.
+     */
+    public function failed(AmountRunningLow $event, Throwable $exception): void
+    {
+        Log::error('Failed to notify admins about critical inventory amount', [
+            'inventory_item_id' => $event->inventoryItem->id,
+            'local_name' => $event->inventoryItem->local_name,
+            'exception' => $exception->getMessage(),
+        ]);
     }
 }

--- a/app/Listeners/InventoryItemAmountCritical.php
+++ b/app/Listeners/InventoryItemAmountCritical.php
@@ -2,52 +2,24 @@
 
 namespace App\Listeners;
 
+use App\Enums\RoleEnum;
 use App\Events\AmountRunningLow;
 use App\Mail\InventoryItemCriticalAmountReached;
-use App\Mail\UserCreatedNotification;
+use App\Models\User;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
-use Spatie\Permission\Models\Role;
 
 class InventoryItemAmountCritical implements ShouldQueue
 {
     /**
-     * Create the event listener.
-     */
-    public function __construct()
-    {
-        //
-    }
-
-    /**
      * Handle the event.
      */
-    public function handle(AmountRunningLow $event): \Illuminate\Http\RedirectResponse
+    public function handle(AmountRunningLow $event): void
     {
-        
-        $adminUsers = Role::findByName('admin')->users;
-        foreach ($adminUsers as $adminUser) {
-            Mail::to($adminUser->email)->send(new InventoryItemCriticalAmountReached($event->inventoryItem, $adminUser));
-        }
+        $recipients = User::role([RoleEnum::ADMIN, RoleEnum::SUPER_ADMIN])->get();
 
-        $superAdminUsers = Role::findByName('super-admin')->users;
-        foreach ($superAdminUsers as $superAdminUser) {
-            Mail::to($superAdminUser->email)->send(new InventoryItemCriticalAmountReached($event->inventoryItem, $superAdminUser));
-        }
-        
-        if($event->readerOrigin){
-            return to_route('reader')
-                ->with('success', __('actions.inventoryItem.updated', [
-                            'local_name' => $event->inventoryItem->local_name]
-                    ) . '.');
-        }
-        else {
-            return to_route('inventoryItems.index')
-                ->with('success', __('actions.inventoryItem.updated', [
-                            'local_name' => $event->inventoryItem->local_name]
-                    ) . '.');
+        foreach ($recipients as $recipient) {
+            Mail::to($recipient->email)->queue(new InventoryItemCriticalAmountReached($event->inventoryItem, $recipient));
         }
     }
 }

--- a/app/Listeners/SendUserCreatedNotification.php
+++ b/app/Listeners/SendUserCreatedNotification.php
@@ -5,17 +5,22 @@ namespace App\Listeners;
 use App\Events\UserCreated;
 use App\Mail\UserCreatedNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
+use Throwable;
 
 class SendUserCreatedNotification implements ShouldQueue
 {
+    public int $tries = 3;
+
     /**
-     * Create the event listener.
+     * Seconds to wait before each retry: 1 minute, then 5, then 15.
+     *
+     * @return array<int, int>
      */
-    public function __construct()
+    public function backoff(): array
     {
-        //
+        return [60, 300, 900];
     }
 
     /**
@@ -24,5 +29,17 @@ class SendUserCreatedNotification implements ShouldQueue
     public function handle(UserCreated $event): void
     {
         Mail::to($event->user->email)->send(new UserCreatedNotification($event->user, $event->password));
+    }
+
+    /**
+     * Handle a job failure.
+     */
+    public function failed(UserCreated $event, Throwable $exception): void
+    {
+        Log::error('Failed to send new-user credentials email', [
+            'user_id' => $event->user->id,
+            'email' => $event->user->email,
+            'exception' => $exception->getMessage(),
+        ]);
     }
 }

--- a/app/Mail/InventoryItemCriticalAmountReached.php
+++ b/app/Mail/InventoryItemCriticalAmountReached.php
@@ -11,7 +11,7 @@ use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 
-class InventoryItemCriticalAmountReached extends Mailable
+class InventoryItemCriticalAmountReached extends Mailable implements ShouldQueue
 {
     use Queueable, SerializesModels;
 
@@ -20,7 +20,7 @@ class InventoryItemCriticalAmountReached extends Mailable
      */
     public function __construct(public InventoryItem $inventoryItem, public User $user)
     {
-        //
+        $this->locale($this->user->locale);
     }
 
     /**
@@ -28,7 +28,7 @@ class InventoryItemCriticalAmountReached extends Mailable
      */
     public function envelope(): Envelope
     {
-        $subject = 'Inventorius '.($this->inventoryItem->local_name).' pasiekė kritinį kiekį.';
+        $subject = __('messages.Inventory.Critical amount subject', ['localName' => $this->inventoryItem->local_name]);
         return new Envelope(
             subject: $subject,
         );

--- a/app/Models/InventoryItem.php
+++ b/app/Models/InventoryItem.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Enums\InventoryStatusEnum;
 use App\Enums\AttributeMerge;
+use App\Events\AmountRunningLow;
 use App\Interfaces\ImportableModel;
 use App\Observers\InventoryItemObserver;
 use App\ValidAttributes;
@@ -240,6 +241,24 @@ class InventoryItem extends Model implements ImportableModel
         return \DB::table($lookup['table'])
             ->where($lookup['match_on'], $value)
             ->value('id');
+    }
+
+    /**
+     * Shared by InventoryItemObserver (direct total_amount edits) and AmountLogObserver
+     * (take-out/return log flow) so the critical-amount notification rule lives in one place.
+     */
+    public function evaluateCriticalAmount(float $remainingAmount, bool $notificationsEnabled): void
+    {
+        if ($remainingAmount <= $this->critical_amount && is_null($this->critical_amount_notified_at)) {
+            if ($notificationsEnabled) {
+                event(new AmountRunningLow($this));
+            }
+            $this->critical_amount_notified_at = now();
+            $this->saveQuietly();
+        } elseif ($remainingAmount > $this->critical_amount && !is_null($this->critical_amount_notified_at)) {
+            $this->critical_amount_notified_at = null;
+            $this->saveQuietly();
+        }
     }
 
 }

--- a/app/Models/Laboratory.php
+++ b/app/Models/Laboratory.php
@@ -60,9 +60,9 @@ class Laboratory extends Model
     {
         return $this->inventoryItems()->count();
     }
-    public function users(): HasMany
+    public function users(): BelongsToMany
     {
-        return $this->hasMany(User::class,'laboratory');
+        return $this->belongsToMany(User::class);
     }
     public function userCount():int
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -31,6 +31,19 @@ class User extends Authenticatable
 {
     use HasFactory, Notifiable, HasRoles, LogsActivity, SoftDeletes, ValidAttributes;
 
+    public const SYSTEM_EMAIL = 'system@internal.local';
+
+    protected static ?self $systemUser = null;
+
+    /**
+     * The bootstrapped system user used as created_by/updated_by for actions
+     * that aren't performed by a real, logged-in user (seeders, imports, jobs).
+     */
+    public static function system(): self
+    {
+        return static::$systemUser ??= static::where('email', self::SYSTEM_EMAIL)->firstOrFail();
+    }
+
     /**
      * The attributes that are mass assignable.
      *
@@ -44,7 +57,6 @@ class User extends Authenticatable
         'password',
         'locale',
         'is_disabled',
-        'laboratory',
         'created_by',
         'updated_by'
     ];
@@ -87,7 +99,7 @@ class User extends Authenticatable
     public function getActivitylogOptions(): logOptions
     {
         return LogOptions::defaults()
-            ->logOnly(['first_name','last_name','email','laboratory'])
+            ->logOnly(['first_name','last_name','email'])
             ->logOnlyDirty()
             ->setDescriptionForEvent(fn(string $eventName) => "This model has been {$eventName}");
     }
@@ -98,9 +110,9 @@ class User extends Authenticatable
         return $role?->name;
     }
 
-    public function belongsToLaboratory(): BelongsTo
+    public function laboratories(): BelongsToMany
     {
-        return $this->belongsTo(Laboratory::class, 'laboratory');
+        return $this->belongsToMany(Laboratory::class);
     }
     
     public function rolesForDisplay(): HasManyThrough
@@ -128,15 +140,27 @@ class User extends Authenticatable
         return $this->belongsToMany(Facility::class);
     }
 
+    public function syncFacilitiesFromLaboratories(): void
+    {
+        $facilityIds = $this->laboratories()
+            ->with('facilities')
+            ->get()
+            ->pluck('facilities')
+            ->flatten()
+            ->pluck('id')
+            ->unique()
+            ->all();
+
+        $this->facilities()->sync($facilityIds);
+    }
+
     public static function getImportForeignKeyLookups(): array
     {
         return [
-            'laboratory' => [
+            'laboratories' => [
                 'table' => 'laboratories',
-                'match_on' => [
-                    'name',
-                    'ident_code',
-                ],
+                'many_to_many' => true,
+                'match_on' => 'name',
             ],
         ];
     }

--- a/app/Observers/AmountLogObserver.php
+++ b/app/Observers/AmountLogObserver.php
@@ -2,7 +2,6 @@
 
 namespace App\Observers;
 
-use App\Events\AmountRunningLow;
 use App\Models\AmountLog;
 use App\Models\SystemConfiguration;
 
@@ -15,28 +14,17 @@ class AmountLogObserver
      */
     public function created(AmountLog $amountLog): void
     {
-
-        $notifyCriticalInventory = SystemConfiguration::where('key','=','critical_notification')->first();
+        $notifyCriticalInventory = SystemConfiguration::where('key', '=', 'critical_notification')->first();
+        $notificationsEnabled = $notifyCriticalInventory != null && (int)$notifyCriticalInventory->value['value'] == 1;
 
         $totalAmountInInventory = $amountLog->inventoryItem->total_amount;
-        $criticalAmountInInventory = $amountLog->inventoryItem->critical_amount;
 
-        $amountRemoved = AmountLog::where('inventory_item_id',$amountLog->inventoryItem->id)->where('action','REMOVE')->sum('amount');
-        $amountReturned = AmountLog::where('inventory_item_id',$amountLog->inventoryItem->id)->where('action','RETURN')->sum('amount');
+        $amountRemoved = AmountLog::where('inventory_item_id', $amountLog->inventoryItem->id)->where('action', 'REMOVE')->sum('amount');
+        $amountReturned = AmountLog::where('inventory_item_id', $amountLog->inventoryItem->id)->where('action', 'RETURN')->sum('amount');
 
         $remainingAmount = $totalAmountInInventory - ($amountRemoved - $amountReturned);
 
-        if ($remainingAmount <= $criticalAmountInInventory && is_null($amountLog->inventoryItem->critical_amount_notified_at)) {
-
-            if ($notifyCriticalInventory != null && (int)$notifyCriticalInventory->value['value'] == 1){
-                event(new AmountRunningLow($amountLog->inventoryItem, false));
-            }
-            $amountLog->inventoryItem->critical_amount_notified_at = now();
-            $amountLog->inventoryItem->saveQuietly();
-        } else if ($remainingAmount > $criticalAmountInInventory && !is_null($amountLog->inventoryItem->critical_amount_notified_at)){
-            $amountLog->inventoryItem->critical_amount_notified_at = null;
-            $amountLog->inventoryItem->saveQuietly();
-        }
+        $amountLog->inventoryItem->evaluateCriticalAmount($remainingAmount, $notificationsEnabled);
     }
 
     /**

--- a/app/Observers/InventoryItemObserver.php
+++ b/app/Observers/InventoryItemObserver.php
@@ -2,11 +2,9 @@
 
 namespace App\Observers;
 
-use App\Events\AmountRunningLow;
 use App\Models\InventoryItem;
 use App\Models\SystemConfiguration;
 use Illuminate\Contracts\Events\ShouldHandleEventsAfterCommit;
-use Illuminate\Support\Facades\Log;
 
 class InventoryItemObserver implements ShouldHandleEventsAfterCommit
 {
@@ -25,24 +23,11 @@ class InventoryItemObserver implements ShouldHandleEventsAfterCommit
      */
     public function updated(InventoryItem $inventoryItem): void
     {
-        if ($inventoryItem->isDirty('total_amount')){
+        if ($inventoryItem->isDirty('total_amount')) {
+            $notifyCriticalInventory = SystemConfiguration::where('key', '=', 'critical_notification')->first();
+            $notificationsEnabled = $notifyCriticalInventory != null && (int)$notifyCriticalInventory->value['value'] == 1;
 
-            $notifyCriticalInventory = SystemConfiguration::where('key','=','critical_notification')->first();
-
-            $criticalAmount = $inventoryItem->critical_amount;
-            if ($inventoryItem->total_amount <= $criticalAmount && is_null($inventoryItem->critical_amount_notified_at)){
-
-                if ($notifyCriticalInventory != null && (int)$notifyCriticalInventory->value['value'] == 1){
-                    event(new AmountRunningLow($inventoryItem, false));
-                }                
-                $inventoryItem->critical_amount_notified_at = now();
-                $inventoryItem->save();
-            }
-            else if ($inventoryItem->total_amount > $criticalAmount && !is_null($inventoryItem->critical_amount_notified_at)){
-                $inventoryItem->critical_amount_notified_at = null;
-                $inventoryItem->save();
-            }
-
+            $inventoryItem->evaluateCriticalAmount($inventoryItem->total_amount, $notificationsEnabled);
         }
     }
 

--- a/app/Observers/LaboratoryObserver.php
+++ b/app/Observers/LaboratoryObserver.php
@@ -8,11 +8,9 @@ class LaboratoryObserver
 {
     public static function syncUserFacilities(Laboratory $laboratory)
     {
-        $facilityIds = $laboratory->facilities()->pluck('facilities.id')->all();
-
         foreach ($laboratory->users as $user)
         {
-            $user->facilities()->sync($facilityIds);
+            $user->syncFacilitiesFromLaboratories();
         }
     }
     /**

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -8,36 +8,6 @@ use Illuminate\Contracts\Events\ShouldHandleEventsAfterCommit;
 class UserObserver implements ShouldHandleEventsAfterCommit
 {
 
-    public function created(User $user)
-    {
-        if ($user->isDirty('laboratory') && $user->laboratory !== null) {
-            
-            $laboratory = $user->belongsToLaboratory()->with('facilities')->first();
-
-            if ($laboratory) {
-
-                $facilityIds = $laboratory->facilities->pluck('id')->toArray();
-                $user->facilities()->sync($facilityIds);
-            
-            }
-        }
-    }
-
-    public function updated(User $user)
-    {
-        if ($user->isDirty('laboratory') && $user->laboratory !== null) {
-            
-            $laboratory = $user->belongsToLaboratory()->with('facilities')->first();
-
-            if ($laboratory) {
-
-                $facilityIds = $laboratory->facilities->pluck('id')->toArray();
-                $user->facilities()->sync($facilityIds);
-            
-            }
-        }
-    }
-
     public function deleting(User $user)
     {
         if ($user->isForceDeleting()) {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -14,7 +14,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        if (class_exists(\Laravel\Telescope\TelescopeServiceProvider::class)) {
+            $this->app->register(\Laravel\Telescope\TelescopeServiceProvider::class);
+            $this->app->register(TelescopeServiceProvider::class);
+        }
     }
 
     /**

--- a/app/Providers/TelescopeServiceProvider.php
+++ b/app/Providers/TelescopeServiceProvider.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Providers;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+use Laravel\Telescope\IncomingEntry;
+use Laravel\Telescope\Telescope;
+use Laravel\Telescope\TelescopeApplicationServiceProvider;
+
+class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
+{
+    /**
+     * Register any application services.
+     */
+    public function register(): void
+    {
+        // Telescope::night();
+
+        $this->hideSensitiveRequestDetails();
+
+        $isLocal = $this->app->environment('local');
+
+        Telescope::filter(function (IncomingEntry $entry) use ($isLocal) {
+            return $isLocal ||
+                   $entry->isReportableException() ||
+                   $entry->isFailedRequest() ||
+                   $entry->isFailedJob() ||
+                   $entry->isScheduledTask() ||
+                   $entry->hasMonitoredTag();
+        });
+    }
+
+    /**
+     * Prevent sensitive request details from being logged by Telescope.
+     */
+    protected function hideSensitiveRequestDetails(): void
+    {
+        if ($this->app->environment('local')) {
+            return;
+        }
+
+        Telescope::hideRequestParameters(['_token']);
+
+        Telescope::hideRequestHeaders([
+            'cookie',
+            'x-csrf-token',
+            'x-xsrf-token',
+        ]);
+    }
+
+    /**
+     * Register the Telescope gate.
+     *
+     * This gate determines who can access Telescope in non-local environments.
+     */
+    protected function gate(): void
+    {
+        Gate::define('viewTelescope', function (User $user) {
+            return $user->hasRole('super-admin');
+        });
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "inertiajs/inertia-laravel": "^1.0",
         "laravel/framework": "^11.0",
         "laravel/sanctum": "^4.0",
+        "laravel/telescope": "^5.20",
         "laravel/tinker": "^2.9",
         "maatwebsite/excel": "3.1.55",
         "milon/barcode": "^11.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1e13c028719704ca18ce46fa7c6d71f3",
+    "content-hash": "2dbde096eae94c7cbce8cb653719049d",
     "packages": [
         {
             "name": "brick/math",
@@ -1690,6 +1690,62 @@
             "time": "2025-01-26T19:34:36+00:00"
         },
         {
+            "name": "laravel/sentinel",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/sentinel.git",
+                "reference": "972d9885d9d14312a118e9565c4e6ecc5e751ea1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/sentinel/zipball/972d9885d9d14312a118e9565c4e6ecc5e751ea1",
+                "reference": "972d9885d9d14312a118e9565c4e6ecc5e751ea1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/container": "^8.37|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.27",
+                "orchestra/testbench": "^6.47.1|^7.56|^8.37|^9.16|^10.9|^11.0",
+                "phpstan/phpstan": "^2.1.33"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Sentinel\\SentinelServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Sentinel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                },
+                {
+                    "name": "Mior Muhammad Zaki",
+                    "email": "mior@laravel.com"
+                }
+            ],
+            "support": {
+                "source": "https://github.com/laravel/sentinel/tree/v1.1.0"
+            },
+            "time": "2026-03-24T14:03:38+00:00"
+        },
+        {
             "name": "laravel/serializable-closure",
             "version": "v2.0.4",
             "source": {
@@ -1749,6 +1805,75 @@
                 "source": "https://github.com/laravel/serializable-closure"
             },
             "time": "2025-03-19T13:51:03+00:00"
+        },
+        {
+            "name": "laravel/telescope",
+            "version": "v5.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/telescope.git",
+                "reference": "38ec6e6006a67e05e0c476c5f8ef3550b72e43d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/telescope/zipball/38ec6e6006a67e05e0c476c5f8ef3550b72e43d8",
+                "reference": "38ec6e6006a67e05e0c476c5f8ef3550b72e43d8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "laravel/framework": "^8.37|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "laravel/sentinel": "^1.0",
+                "php": "^8.0",
+                "symfony/console": "^5.3|^6.0|^7.0|^8.0",
+                "symfony/var-dumper": "^5.0|^6.0|^7.0|^8.0"
+            },
+            "require-dev": {
+                "ext-gd": "*",
+                "guzzlehttp/guzzle": "^6.0|^7.0",
+                "laravel/octane": "^1.4|^2.0",
+                "orchestra/testbench": "^6.47.1|^7.55|^8.36|^9.15|^10.8|^11.0",
+                "phpstan/phpstan": "^1.10"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Telescope\\TelescopeServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Telescope\\": "src/",
+                    "Laravel\\Telescope\\Database\\Factories\\": "database/factories/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                },
+                {
+                    "name": "Mohamed Said",
+                    "email": "mohamed@laravel.com"
+                }
+            ],
+            "description": "An elegant debug assistant for the Laravel framework.",
+            "keywords": [
+                "debugging",
+                "laravel",
+                "monitoring"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/telescope/issues",
+                "source": "https://github.com/laravel/telescope/tree/v5.20.0"
+            },
+            "time": "2026-04-06T12:52:26+00:00"
         },
         {
             "name": "laravel/tinker",

--- a/config/steam_validations.php
+++ b/config/steam_validations.php
@@ -38,7 +38,10 @@ return [
         'first_name' => ['required'],
         'last_name' => ['required'],
         'email' => ['required'],
-        'laboratory' => ['required', new ExistsByNumericOrString(table: 'laboratories',attributeName: 'laboratory')],
+        'laboratories' => ['required',
+            new HasRelationMethod(modelClass: App\Models\User::class, relationName: 'laboratories'),
+            new ExistsByNumericOrString(table: 'laboratories', attributeName: 'laboratories', idColumn: 'id', nameColumn: 'name', allowPipeSeparated: true),
+        ],
     ],
     'App\\Models\\Laboratory' => [
         'name' => ['required'],

--- a/config/telescope.php
+++ b/config/telescope.php
@@ -1,0 +1,212 @@
+<?php
+
+use Laravel\Telescope\Http\Middleware\Authorize;
+use Laravel\Telescope\Watchers;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Telescope Master Switch
+    |--------------------------------------------------------------------------
+    |
+    | This option may be used to disable all Telescope watchers regardless
+    | of their individual configuration, which simply provides a single
+    | and convenient way to enable or disable Telescope data storage.
+    |
+    */
+
+    'enabled' => env('TELESCOPE_ENABLED', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Telescope Domain
+    |--------------------------------------------------------------------------
+    |
+    | This is the subdomain where Telescope will be accessible from. If the
+    | setting is null, Telescope will reside under the same domain as the
+    | application. Otherwise, this value will be used as the subdomain.
+    |
+    */
+
+    'domain' => env('TELESCOPE_DOMAIN'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Telescope Path
+    |--------------------------------------------------------------------------
+    |
+    | This is the URI path where Telescope will be accessible from. Feel free
+    | to change this path to anything you like. Note that the URI will not
+    | affect the paths of its internal API that aren't exposed to users.
+    |
+    */
+
+    'path' => env('TELESCOPE_PATH', 'telescope'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Telescope Storage Driver
+    |--------------------------------------------------------------------------
+    |
+    | This configuration options determines the storage driver that will
+    | be used to store Telescope's data. In addition, you may set any
+    | custom options as needed by the particular driver you choose.
+    |
+    */
+
+    'driver' => env('TELESCOPE_DRIVER', 'database'),
+
+    'storage' => [
+        'database' => [
+            'connection' => env('DB_CONNECTION', 'mysql'),
+            'chunk' => 1000,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Telescope Queue
+    |--------------------------------------------------------------------------
+    |
+    | This configuration options determines the queue connection and queue
+    | which will be used to process ProcessPendingUpdate jobs. This can
+    | be changed if you would prefer to use a non-default connection.
+    |
+    */
+
+    'queue' => [
+        'connection' => env('TELESCOPE_QUEUE_CONNECTION'),
+        'queue' => env('TELESCOPE_QUEUE'),
+        'delay' => env('TELESCOPE_QUEUE_DELAY', 10),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Telescope Route Middleware
+    |--------------------------------------------------------------------------
+    |
+    | These middleware will be assigned to every Telescope route, giving you
+    | the chance to add your own middleware to this list or change any of
+    | the existing middleware. Or, you can simply stick with this list.
+    |
+    */
+
+    'middleware' => [
+        'web',
+        Authorize::class,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Allowed / Ignored Paths & Commands
+    |--------------------------------------------------------------------------
+    |
+    | The following array lists the URI paths and Artisan commands that will
+    | not be watched by Telescope. In addition to this list, some Laravel
+    | commands, like migrations and queue commands, are always ignored.
+    |
+    */
+
+    'only_paths' => [
+        // 'api/*'
+    ],
+
+    'ignore_paths' => [
+        'livewire*',
+        'nova-api*',
+        'pulse*',
+        '_boost*',
+        '.well-known*',
+    ],
+
+    'ignore_commands' => [
+        //
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Telescope Watchers
+    |--------------------------------------------------------------------------
+    |
+    | The following array lists the "watchers" that will be registered with
+    | Telescope. The watchers gather the application's profile data when
+    | a request or task is executed. Feel free to customize this list.
+    |
+    */
+
+    'watchers' => [
+        Watchers\BatchWatcher::class => env('TELESCOPE_BATCH_WATCHER', true),
+
+        Watchers\CacheWatcher::class => [
+            'enabled' => env('TELESCOPE_CACHE_WATCHER', true),
+            'hidden' => [],
+            'ignore' => [],
+        ],
+
+        Watchers\ClientRequestWatcher::class => [
+            'enabled' => env('TELESCOPE_CLIENT_REQUEST_WATCHER', true),
+            'ignore_hosts' => [],
+        ],
+
+        Watchers\CommandWatcher::class => [
+            'enabled' => env('TELESCOPE_COMMAND_WATCHER', true),
+            'ignore' => [],
+        ],
+
+        Watchers\DumpWatcher::class => [
+            'enabled' => env('TELESCOPE_DUMP_WATCHER', true),
+            'always' => env('TELESCOPE_DUMP_WATCHER_ALWAYS', false),
+        ],
+
+        Watchers\EventWatcher::class => [
+            'enabled' => env('TELESCOPE_EVENT_WATCHER', true),
+            'ignore' => [],
+        ],
+
+        Watchers\ExceptionWatcher::class => env('TELESCOPE_EXCEPTION_WATCHER', true),
+
+        Watchers\GateWatcher::class => [
+            'enabled' => env('TELESCOPE_GATE_WATCHER', true),
+            'ignore_abilities' => [],
+            'ignore_packages' => true,
+            'ignore_paths' => [],
+        ],
+
+        Watchers\JobWatcher::class => env('TELESCOPE_JOB_WATCHER', true),
+
+        Watchers\LogWatcher::class => [
+            'enabled' => env('TELESCOPE_LOG_WATCHER', true),
+            'level' => 'error',
+        ],
+
+        Watchers\MailWatcher::class => env('TELESCOPE_MAIL_WATCHER', true),
+
+        Watchers\ModelWatcher::class => [
+            'enabled' => env('TELESCOPE_MODEL_WATCHER', true),
+            'events' => ['eloquent.*'],
+            'hydrations' => true,
+        ],
+
+        Watchers\NotificationWatcher::class => env('TELESCOPE_NOTIFICATION_WATCHER', true),
+
+        Watchers\QueryWatcher::class => [
+            'enabled' => env('TELESCOPE_QUERY_WATCHER', true),
+            'ignore_packages' => true,
+            'ignore_paths' => [],
+            'slow' => 100,
+        ],
+
+        Watchers\RedisWatcher::class => env('TELESCOPE_REDIS_WATCHER', true),
+
+        Watchers\RequestWatcher::class => [
+            'enabled' => env('TELESCOPE_REQUEST_WATCHER', true),
+            'size_limit' => env('TELESCOPE_RESPONSE_SIZE_LIMIT', 64),
+            'ignore_http_methods' => [],
+            'ignore_status_codes' => [],
+        ],
+
+        Watchers\ScheduleWatcher::class => env('TELESCOPE_SCHEDULE_WATCHER', true),
+        Watchers\ViewWatcher::class => env('TELESCOPE_VIEW_WATCHER', true),
+    ],
+];

--- a/database/factories/InventoryItemFactory.php
+++ b/database/factories/InventoryItemFactory.php
@@ -3,6 +3,9 @@
 namespace Database\Factories;
 
 use App\Models\InventoryItem;
+use App\Models\ItemType;
+use App\Models\Laboratory;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -25,13 +28,12 @@ class InventoryItemFactory extends Factory
         $prefix = $prefixes[intdiv($index, 999) % count($prefixes)];
         $suffixNumber = str_pad(($index % 999) + 1, 3, '0', STR_PAD_LEFT);
         $postfix = $this->faker->randomElement($postfixes);
-        $inventoryTypes = [1, 2, 3, 4, 5];
         $index++;
 
         $nameValue = $this->faker->words($this->faker->randomElement([1, 2, 3, 4, 5]),true);
         return [
             'local_name' => $prefix . $suffixNumber . '-' . $postfix,
-            'inventory_type' => $this->faker->randomElement($inventoryTypes),
+            'inventory_type' => ItemType::query()->inRandomOrder()->value('id'),
             'name' => $nameValue,
             'name_eng' => $nameValue,
             'formula' => $this->faker->regexify('[A-Z0-9]{8}'),
@@ -45,13 +47,13 @@ class InventoryItemFactory extends Factory
             'total_amount' => $this->faker->randomDigitNotZero(),
             'critical_amount' => $this->faker->randomDigitNotZero(),
             'multiple_locations' => $this->faker->boolean(),
-            'laboratory' => 1,
+            'laboratory' => Laboratory::query()->inRandomOrder()->value('id'),
             'storage_conditions' => $this->faker->text(50),
             'asset_number' => $this->faker->uuid,
             'used_for' => $this->faker->text(50),
             'comments' => $this->faker->text(50),
-            'created_by' => 1,
-            'updated_by' => 1,
+            'created_by' => User::system()->id,
+            'updated_by' => User::system()->id,
         ];
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -23,12 +23,18 @@ class UserFactory extends Factory
      */
     public function definition(): array
     {
+        $firstName = fake()->firstName();
+        $lastName = fake()->lastName();
         return [
-            'name' => fake()->name(),
+            'first_name' => $firstName,
+            'last_name' => $lastName,
+            'name' => $firstName . ' ' . $lastName,
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'created_by' => 1,
+            'updated_by' => 1,
         ];
     }
 

--- a/database/migrations/2026_06_20_000001_create_laboratory_user_table.php
+++ b/database/migrations/2026_06_20_000001_create_laboratory_user_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('laboratory_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('laboratory_id')->constrained()->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('laboratory_user');
+    }
+};

--- a/database/migrations/2026_06_20_000002_migrate_user_laboratory_to_pivot.php
+++ b/database/migrations/2026_06_20_000002_migrate_user_laboratory_to_pivot.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('users')
+            ->whereNotNull('laboratory')
+            ->select('id', 'laboratory')
+            ->orderBy('id')
+            ->each(function ($user) {
+                DB::table('laboratory_user')->insert([
+                    'user_id' => $user->id,
+                    'laboratory_id' => $user->laboratory,
+                ]);
+            });
+
+        DB::table('users')->update(['laboratory' => null]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('laboratory_user')
+            ->orderBy('user_id')
+            ->each(function ($pivotRow) {
+                DB::table('users')
+                    ->where('id', $pivotRow->user_id)
+                    ->update(['laboratory' => $pivotRow->laboratory_id]);
+            });
+
+        DB::table('laboratory_user')->truncate();
+    }
+};

--- a/database/migrations/2026_06_20_000003_create_system_user.php
+++ b/database/migrations/2026_06_20_000003_create_system_user.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (DB::table('users')->where('email', User::SYSTEM_EMAIL)->exists()) {
+            return;
+        }
+
+        $driver = DB::connection()->getDriverName();
+
+        $this->toggleForeignKeyChecks($driver, false);
+
+        $systemUserId = DB::table('users')->insertGetId([
+            'name' => 'System',
+            'first_name' => 'System',
+            'last_name' => 'System',
+            'email' => User::SYSTEM_EMAIL,
+            'locale' => 'en',
+            'is_disabled' => true,
+            'email_verified_at' => now(),
+            'password' => Hash::make(Str::random(40)),
+            'created_by' => 0,
+            'updated_by' => 0,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('users')->where('id', $systemUserId)->update([
+            'created_by' => $systemUserId,
+            'updated_by' => $systemUserId,
+        ]);
+
+        $this->toggleForeignKeyChecks($driver, true);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('users')->where('email', User::SYSTEM_EMAIL)->delete();
+    }
+
+    /**
+     * The system user's created_by/updated_by self-reference doesn't exist yet at insert time,
+     * so foreign key checks need to be relaxed for the single bootstrap insert.
+     */
+    private function toggleForeignKeyChecks(string $driver, bool $enabled): void
+    {
+        match ($driver) {
+            'sqlite' => DB::statement('PRAGMA foreign_keys = ' . ($enabled ? 'ON' : 'OFF')),
+            'mysql' => DB::statement('SET FOREIGN_KEY_CHECKS=' . ($enabled ? 1 : 0)),
+            default => null,
+        };
+    }
+};

--- a/database/migrations/2026_06_20_213948_create_telescope_entries_table.php
+++ b/database/migrations/2026_06_20_213948_create_telescope_entries_table.php
@@ -1,0 +1,70 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Get the migration connection name.
+     */
+    public function getConnection(): ?string
+    {
+        return config('telescope.storage.database.connection');
+    }
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $schema = Schema::connection($this->getConnection());
+
+        $schema->create('telescope_entries', function (Blueprint $table) {
+            $table->bigIncrements('sequence');
+            $table->uuid('uuid');
+            $table->uuid('batch_id');
+            $table->string('family_hash')->nullable();
+            $table->boolean('should_display_on_index')->default(true);
+            $table->string('type', 20);
+            $table->longText('content');
+            $table->dateTime('created_at')->nullable();
+
+            $table->unique('uuid');
+            $table->index('batch_id');
+            $table->index('family_hash');
+            $table->index('created_at');
+            $table->index(['type', 'should_display_on_index']);
+        });
+
+        $schema->create('telescope_entries_tags', function (Blueprint $table) {
+            $table->uuid('entry_uuid');
+            $table->string('tag');
+
+            $table->primary(['entry_uuid', 'tag']);
+            $table->index('tag');
+
+            $table->foreign('entry_uuid')
+                ->references('uuid')
+                ->on('telescope_entries')
+                ->cascadeOnDelete();
+        });
+
+        $schema->create('telescope_monitoring', function (Blueprint $table) {
+            $table->string('tag')->primary();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $schema = Schema::connection($this->getConnection());
+
+        $schema->dropIfExists('telescope_entries_tags');
+        $schema->dropIfExists('telescope_entries');
+        $schema->dropIfExists('telescope_monitoring');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -18,6 +18,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
+        $systemUserId = User::system()->id;
 
         $adminRole = [
             'id' => 1,
@@ -42,8 +43,8 @@ class DatabaseSeeder extends Seeder
             'is_disabled' => false,
             'email_verified_at' => time(),
             'locale' => 'lt',
-            'created_by' => 1,
-            'updated_by' => 1
+            'created_by' => $systemUserId,
+            'updated_by' => $systemUserId
         ]);
 
         $adminUser->assignRole('admin');
@@ -57,8 +58,8 @@ class DatabaseSeeder extends Seeder
             'is_disabled' => false,
             'email_verified_at' => time(),
             'locale' => 'lt',
-            'created_by' => 1,
-            'updated_by' => 1
+            'created_by' => $systemUserId,
+            'updated_by' => $systemUserId
         ]);
 
         $regularUser->assignRole('user');
@@ -69,46 +70,44 @@ class DatabaseSeeder extends Seeder
             'updated_by' => $adminUser->id
         ]);
 
-        $adminUser->laboratory = $laboratory->id;
-        $adminUser->save();
-        $regularUser->laboratory = $laboratory->id;
-        $regularUser->save();
+        $adminUser->laboratories()->sync([$laboratory->id]);
+        $adminUser->syncFacilitiesFromLaboratories();
+        $regularUser->laboratories()->sync([$laboratory->id]);
+        $regularUser->syncFacilitiesFromLaboratories();
 
         ItemType::factory()->create([
             'name' => 'Atsargos (kitos sunaudojamos atsargos)',
             'change_acc_amount' => 1,
-            'created_by' => 1,
-            'updated_by' => 1
+            'created_by' => $systemUserId,
+            'updated_by' => $systemUserId
         ]);
 
         ItemType::factory()->create([
             'name' => 'Ilgalaikis (kompiuterinė t..)',
             'change_acc_amount' => 0,
-            'created_by' => 1,
-            'updated_by' => 1
+            'created_by' => $systemUserId,
+            'updated_by' => $systemUserId
         ]);
 
         ItemType::factory()->create([
             'name' => 'Ilgalaikis (laboratorinė technika)',
             'change_acc_amount' => 0,
-            'created_by' => 1,
-            'updated_by' => 1
+            'created_by' => $systemUserId,
+            'updated_by' => $systemUserId
         ]);
 
         ItemType::factory()->create([
             'name' => 'Trumpalaikis (susidėvinčios priemonės)',
             'change_acc_amount' => 0,
-            'created_by' => 1,
-            'updated_by' => 1
+            'created_by' => $systemUserId,
+            'updated_by' => $systemUserId
         ]);
 
         ItemType::factory()->create([
             'name' => 'Atsargos (Reagentai)',
             'change_acc_amount' => 1,
-            'created_by' => 1,
-            'updated_by' => 1
+            'created_by' => $systemUserId,
+            'updated_by' => $systemUserId
         ]);
-
-        $regularUser->save(['laboratory' => 1]);
     }
 }

--- a/database/seeders/SeedInventoryItems.php
+++ b/database/seeders/SeedInventoryItems.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\InventoryItem;
+use App\Models\ItemType;
+use App\Models\Laboratory;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class SeedInventoryItems extends Seeder
+{
+    /**
+     * How many inventory items to create per laboratory.
+     */
+    private const ITEMS_PER_LABORATORY = 10;
+
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $laboratories = Laboratory::query()->with('facilities')->get();
+
+        if ($laboratories->isEmpty() || ItemType::query()->count() === 0) {
+            $this->command->warn('No laboratories or item types found - run SeedLabsAndFacs and DatabaseSeeder first.');
+            return;
+        }
+
+        $systemUserId = User::system()->id;
+        $cupboards = range(1, 20);
+        $shelves = range('A', 'F');
+
+        foreach ($laboratories as $laboratory) {
+            for ($i = 0; $i < self::ITEMS_PER_LABORATORY; $i++) {
+                $inventoryItem = InventoryItem::factory()->create([
+                    'laboratory' => $laboratory->id,
+                    'cupboard' => (string) fake()->randomElement($cupboards),
+                    'shelf' => fake()->randomElement($shelves),
+                    'created_by' => $systemUserId,
+                    'updated_by' => $systemUserId,
+                ]);
+
+                if ($laboratory->facilities->isNotEmpty()) {
+                    $facilityIds = $laboratory->facilities
+                        ->random(min(fake()->numberBetween(1, 2), $laboratory->facilities->count()))
+                        ->pluck('id')
+                        ->all();
+                    $inventoryItem->facilities()->sync($facilityIds);
+                }
+            }
+            $this->command->info("Seeded " . self::ITEMS_PER_LABORATORY . " inventory items for lab '{$laboratory->name}'");
+        }
+    }
+}

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -13,6 +13,7 @@ return [
     ],
     'Inventory' => [
         'Inventory item is too low or changed' => 'Inventory item <strong>:localName</strong> has reached the critical amount, please order more or check the current amount.',
+        'Critical amount subject' => 'Inventory item :localName has reached the critical amount',
     ],
     'Import' => [
         'Failed imports' => 'Your recent import has been processeced, however some items have failed to import. Please find the attached report to amend the failed items.',

--- a/lang/lt/messages.php
+++ b/lang/lt/messages.php
@@ -13,6 +13,7 @@ return [
     ],
     'Inventory' => [
         'Inventory item is too low or changed' => 'Inventoriaus įrašas <strong>:localName</strong> pasiekė kritinį kiekį, prašome užsakyti jo daugiau arba peržvelgti turimą kiekį.',
+        'Critical amount subject' => 'Inventoriaus įrašas :localName pasiekė kritinį kiekį',
     ],
     'Import' => [
         'Failed imports' => 'Jūsų neseniai įkeltas importas baigtas, tačiau tam tikri įrašai sėkmingai neįsikėlė. Prašome peržvelkti prisegtuką ir patikrinti duomenų klaidas.',

--- a/resources/js/Pages/Inventory/Edit.jsx
+++ b/resources/js/Pages/Inventory/Edit.jsx
@@ -16,6 +16,8 @@ import SecondaryButton from "@/Components/SecondaryButton.jsx";
 import DeleteButton from "@/Components/Forms/DeleteButton.jsx";
 import { useState, useEffect, useRef } from 'react';
 import FlexibleStaticSelect from '@/Components/Forms/FlexibleStaticSelect';
+import MiscButton from "@/Components/Forms/MiscButton.jsx";
+import { TbEye } from "react-icons/tb";
 
 export default function Edit({auth, inventoryItem, logsForItem, laboratories, facilities, itemTypes, queryParams, referrer, cupboardOptions, shelfOptions, can}) {
     const isFirstLoad = useRef(true);
@@ -98,6 +100,16 @@ export default function Edit({auth, inventoryItem, logsForItem, laboratories, fa
             header={
                 <div className="flex justify-between items-center">
                     <h2 className="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">{StringHelper.__("Edit")} - {inventoryItem.data.name}</h2>
+                    <div className="flex space-x-2 h-12">
+                        <MiscButton
+                            classVariant="blue"
+                            title={StringHelper.__("View")}
+                            as="link"
+                            to={route("inventoryItems.show", {inventoryItem: inventoryItem.data.id, query: queryParams, referrer: referrer})}
+                            icon={TbEye}
+                            children={StringHelper.__("View")}
+                        />
+                    </div>
                 </div>
             }
         >

--- a/resources/js/Pages/Inventory/Show.jsx
+++ b/resources/js/Pages/Inventory/Show.jsx
@@ -12,9 +12,11 @@ import HistoryLog from "@/Components/Forms/HistoryLog.jsx";
 import ActionButton from '@/Components/Forms/ActionButton';
 import FlexibleStaticSelect from '@/Components/Forms/FlexibleStaticSelect';
 import LogsTable from "@/Components/Forms/LogsTable.jsx";
+import MiscButton from "@/Components/Forms/MiscButton.jsx";
+import { TbEdit, TbArrowsUpDown } from "react-icons/tb";
 
 
-export default function Show({auth, inventoryItem, logsForItem, laboratories, facilities, itemTypes, queryParams, referrer, cupboardOptions, shelfOptions}) {
+export default function Show({auth, inventoryItem, logsForItem, laboratories, facilities, itemTypes, queryParams, referrer, cupboardOptions, shelfOptions, can}) {
     const [openAll, setOpenAll] = useState(true);
     const toggleAllAccordions = () => {
         setOpenAll(!openAll);
@@ -35,6 +37,24 @@ export default function Show({auth, inventoryItem, logsForItem, laboratories, fa
                             nameOfCloseButton={StringHelper.__("Close")}
                         ></HistoryLog>
                         <ActionButton onClick={toggleAllAccordions} title={StringHelper.__("Toggle if the form should be fully expanded or collapsed") + '.'} className="text-lg">{openAll ? StringHelper.__("Collapse form") : StringHelper.__("Expand form")}</ActionButton>
+                        {can.edit && (
+                            <MiscButton
+                                classVariant="green"
+                                title={StringHelper.__("Edit")}
+                                as="link"
+                                to={route("inventoryItems.editRaw", {inventoryItem: inventoryItem.data.id, query: queryParams, referrer: referrer})}
+                                icon={TbEdit}
+                                children={StringHelper.__("Edit")}
+                            />
+                        )}
+                        <MiscButton
+                            classVariant="green"
+                            title={StringHelper.__("Edit amount")}
+                            as="link"
+                            to={route("inventoryItems.edit", {inventoryItem: inventoryItem.data.id, query: queryParams, referrer: referrer})}
+                            icon={TbArrowsUpDown}
+                            children={StringHelper.__("Change amount")}
+                        />
                     </div>
                 </div>
             }

--- a/resources/js/Pages/User/Edit.jsx
+++ b/resources/js/Pages/User/Edit.jsx
@@ -9,8 +9,10 @@ import InformationIconToolTip from "@/Components/InformationIconToolTip.jsx";
 import PrimaryButton from "@/Components/PrimaryButton.jsx";
 import AccordionWithManualIndex from "@/Components/Forms/AccordionWithManualIndex.jsx";
 import NumericInput from "@/Components/Forms/NumericInput.jsx";
+import MiscButton from "@/Components/Forms/MiscButton.jsx";
+import { TbEye, TbEdit } from "react-icons/tb";
 
-export default function Edit({auth, inventoryItem, redirectToReader, queryParams, referrer}) {
+export default function Edit({auth, inventoryItem, redirectToReader, queryParams, referrer, can}) {
     const {data, setData, patch, errors, processing} = useForm({
         total_amount: inventoryItem.total_amount,
         amount_added: '',
@@ -42,6 +44,28 @@ export default function Edit({auth, inventoryItem, redirectToReader, queryParams
             header={
                 <div className="flex justify-between items-center">
                     <h2 className="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">{StringHelper.__("Change amount")} - {inventoryItem.local_name} - {inventoryItem.name}</h2>
+                    {!redirectToReader && (
+                        <div className="flex space-x-2 h-12">
+                            <MiscButton
+                                classVariant="blue"
+                                title={StringHelper.__("View")}
+                                as="link"
+                                to={route("inventoryItems.show", {inventoryItem: inventoryItem.id, query: queryParams, referrer: referrer})}
+                                icon={TbEye}
+                                children={StringHelper.__("View")}
+                            />
+                            {can.edit && (
+                                <MiscButton
+                                    classVariant="green"
+                                    title={StringHelper.__("Full edit")}
+                                    as="link"
+                                    to={route("inventoryItems.editRaw", {inventoryItem: inventoryItem.id, query: queryParams, referrer: referrer})}
+                                    icon={TbEdit}
+                                    children={StringHelper.__("Full edit")}
+                                />
+                            )}
+                        </div>
+                    )}
                 </div>
             }
         >

--- a/resources/js/Pages/User/EditLog.jsx
+++ b/resources/js/Pages/User/EditLog.jsx
@@ -17,8 +17,10 @@ import NumericInput from "@/Components/Forms/NumericInput.jsx";
 import {FaQrcode} from "react-icons/fa";
 import {MdClose} from "react-icons/md";
 import LogsTable from "@/Components/Forms/LogsTable.jsx";
+import MiscButton from "@/Components/Forms/MiscButton.jsx";
+import { TbEye, TbEdit } from "react-icons/tb";
 
-export default function Edit({auth, inventoryItem, logsForItem, totalInUse, laboratories, redirectToReader, queryParams, referrer}) {
+export default function Edit({auth, inventoryItem, logsForItem, totalInUse, laboratories, redirectToReader, queryParams, referrer, can}) {
     const [actionFromUser, setActionFromUser] = useState('REMOVE');
     const {data, setData, patch, errors} = useForm({
         total_amount: inventoryItem.total_amount,
@@ -51,6 +53,28 @@ export default function Edit({auth, inventoryItem, logsForItem, totalInUse, labo
             header={
                 <div className="flex justify-between items-center">
                     <h2 className="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">{StringHelper.__("Change amount")} - {inventoryItem.local_name} - {inventoryItem.name}</h2>
+                    {!redirectToReader && (
+                        <div className="flex space-x-2 h-12">
+                            <MiscButton
+                                classVariant="blue"
+                                title={StringHelper.__("View")}
+                                as="link"
+                                to={route("inventoryItems.show", {inventoryItem: inventoryItem.id, query: queryParams, referrer: referrer})}
+                                icon={TbEye}
+                                children={StringHelper.__("View")}
+                            />
+                            {can.edit && (
+                                <MiscButton
+                                    classVariant="green"
+                                    title={StringHelper.__("Full edit")}
+                                    as="link"
+                                    to={route("inventoryItems.editRaw", {inventoryItem: inventoryItem.id, query: queryParams, referrer: referrer})}
+                                    icon={TbEdit}
+                                    children={StringHelper.__("Full edit")}
+                                />
+                            )}
+                        </div>
+                    )}
                 </div>
             }
         >

--- a/resources/js/Pages/Users/Create.jsx
+++ b/resources/js/Pages/Users/Create.jsx
@@ -17,19 +17,25 @@ export default function Create({ auth, roles, laboratories, facilities }) {
         last_name: '',
         email: '',
         password: '',
-        laboratory: '',
+        laboratories: [],
         selectedRole: '',
     });
     useEffect(() => {
-        setWilledFacility(facilities[data.laboratory]);
-        let values = [];
-        if (data.laboratory !== '') {
-            facilities[data.laboratory].forEach(facility => {
-                values.push(facility.value);
+        const unionFacilities = [];
+        data.laboratories.forEach(laboratoryId => {
+            (facilities[laboratoryId] || []).forEach(facility => {
+                if (!unionFacilities.some(existing => existing.value === facility.value)) {
+                    unionFacilities.push(facility);
+                }
             });
-        }
-        setMappedFacility(values);
-    }, [data.laboratory]);
+        });
+        setWilledFacility(unionFacilities);
+        setMappedFacility(unionFacilities.map(facility => facility.value));
+    }, [data.laboratories]);
+
+    const handleLaboratoryChange = (e) => {
+        setData('laboratories', e);
+    };
 
     const onSubmit = (e) => {
         e.preventDefault();
@@ -72,12 +78,10 @@ export default function Create({ auth, roles, laboratories, facilities }) {
                             <InputError message={errors.email} className="mt-2" />
                         </div>
                         <div className="mt-4">
-                            <InputLabel htmlFor="user_laboratory">{StringHelper.__("Laboratory")}<span className="text-red-500">*</span></InputLabel>
-                            <select className="border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-sm mt-1 block w-full" value={data.laboratory} onChange={e => setData('laboratory', e.target.value)}>
-                                <option value="">{StringHelper.__("Choose a value")}</option>
-                                {laboratories.data.map((laboratory) => (<option key={laboratory.value} value={laboratory.value}>{laboratory.label}</option>))}
-                            </select>
-                            <InputError message={errors.laboratory} className="mt-2" />
+                            <InputLabel htmlFor="user_laboratories">{StringHelper.__("Laboratories")}<span className="text-red-500">*</span></InputLabel>
+                            <FlexibleStaticSelect id="user_laboratories" value={data.laboratories} onChange={handleLaboratoryChange} options={laboratories.data}
+                                customIsMulti={true} customPlaceHolder={StringHelper.__("Choose a value")} customNoOptionsMessage={StringHelper.__("No options")} />
+                            <InputError message={errors.laboratories} className="mt-2" />
                         </div>
                         <div className="mt-4">
                             <InputLabel htmlFor="user_facility">{StringHelper.__("Facility")}</InputLabel>

--- a/resources/js/Pages/Users/Edit.jsx
+++ b/resources/js/Pages/Users/Edit.jsx
@@ -18,21 +18,26 @@ export default function Edit({ auth, user, userRole, roles, laboratories, facili
         first_name: user.data.first_name || '',
         last_name: user.data.last_name || '',
         email: user.data.email || '',
-        laboratory: user.data.laboratory,
+        laboratories: user.data.laboratories || [],
         role: userRole,
     })
-    const [willedFacility, setWilledFacility] = useState(facilities[data.laboratory] || []);
+    const [willedFacility, setWilledFacility] = useState([]);
     const [mappedFacility, setMappedFacility] = useState(user.data.facilities || []);
     useEffect(() => {
-        setWilledFacility(facilities[data.laboratory]);
-        let values = [];
-        if (data.laboratory !== '') {
-            facilities[data.laboratory].forEach(facility => {
-                values.push(facility.value);
+        const unionFacilities = [];
+        data.laboratories.forEach(laboratoryId => {
+            (facilities[laboratoryId] || []).forEach(facility => {
+                if (!unionFacilities.some(existing => existing.value === facility.value)) {
+                    unionFacilities.push(facility);
+                }
             });
-        }
-        setMappedFacility(values);
-    }, [data.laboratory]);
+        });
+        setWilledFacility(unionFacilities);
+        setMappedFacility(unionFacilities.map(facility => facility.value));
+    }, [data.laboratories]);
+    const handleLaboratoryChange = (e) => {
+        setData('laboratories', e);
+    };
     const onSubmit = (e) => {
         e.preventDefault();
 
@@ -81,16 +86,11 @@ export default function Edit({ auth, user, userRole, roles, laboratories, facili
                             <InputError message={errors.email} className="mt-2" />
                         </div>
                         <div className="mt-4">
-                            <InputLabel htmlFor="user_laboratory">{StringHelper.__("Laboratory")}<span
+                            <InputLabel htmlFor="user_laboratories">{StringHelper.__("Laboratories")}<span
                                 className="text-red-500">*</span></InputLabel>
-                            <select id="user_laboratory" name="laboratory"
-                                className="border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-sm mt-1 block w-full"
-                                value={data.laboratory} onChange={e => setData('laboratory', e.target.value)}>
-                                <option value="">{StringHelper.__("Choose a value")}</option>
-                                {laboratories.map((laboratory) => (
-                                    <option key={laboratory.id} value={laboratory.id}>{laboratory.name}</option>))}
-                            </select>
-                            <InputError message={errors.laboratory} className="mt-2" />
+                            <FlexibleStaticSelect id="user_laboratories" value={data.laboratories} onChange={handleLaboratoryChange} options={laboratories.data}
+                                customIsMulti={true} customPlaceHolder={StringHelper.__("Choose a value")} customNoOptionsMessage={StringHelper.__("No options")} />
+                            <InputError message={errors.laboratories} className="mt-2" />
                         </div>
                         <div className="mt-4">
                             <InputLabel htmlFor="user_facility">{StringHelper.__("Facility")}</InputLabel>

--- a/resources/js/Pages/Users/Show.jsx
+++ b/resources/js/Pages/Users/Show.jsx
@@ -35,11 +35,9 @@ export default function Show({ auth, user, userRole, roles, laboratories, facili
                             <TextInput id="user_email" type="email" name="email" value={user.data.email} className="mt-1 block w-full disabled:bg-gray-400 disabled:text-white" readOnly={true} disabled={true} />
                         </div>
                         <div className="mt-4">
-                            <InputLabel htmlFor="user_laboratory" value={StringHelper.__("Laboratory")} />
-                            <select disabled={true} className="disabled:bg-gray-400 disabled:text-white border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-sm mt-1 block w-full" value={user.data.laboratory}>
-                                <option>{StringHelper.__("Choose a value")}</option>
-                                {laboratories.map((laboratory) => (<option key={laboratory.id} value={laboratory.id}>{laboratory.name}</option>))}
-                            </select>
+                            <InputLabel htmlFor="user_laboratories" value={StringHelper.__("Laboratories")} />
+                            <FlexibleStaticSelect id="user_laboratories" value={user.data.laboratories} customIsDisabled={true} options={laboratories.data}
+                                customIsMulti={true} customPlaceHolder={StringHelper.__("Choose a value")} customNoOptionsMessage={StringHelper.__("No options")} />
                         </div>
                         <div className="mt-4">
                             <InputLabel htmlFor="user_facility">{StringHelper.__("Facility")}</InputLabel>

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,7 +2,10 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote')->hourly();
+
+Schedule::command('telescope:prune --hours=72')->daily();

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -49,6 +49,6 @@ class AuthenticationTest extends TestCase
         $response = $this->actingAs($user)->post('/logout');
 
         $this->assertGuest();
-        $response->assertRedirect('/');
+        $response->assertRedirect('/login');
     }
 }

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -8,24 +8,4 @@ use Tests\TestCase;
 class RegistrationTest extends TestCase
 {
     use RefreshDatabase;
-
-    public function test_registration_screen_can_be_rendered(): void
-    {
-        $response = $this->get('/register');
-
-        $response->assertStatus(200);
-    }
-
-    public function test_new_users_can_register(): void
-    {
-        $response = $this->post('/register', [
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-            'password' => 'password',
-            'password_confirmation' => 'password',
-        ]);
-
-        $this->assertAuthenticated();
-        $response->assertRedirect(route('dashboard', absolute: false));
-    }
 }

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -12,7 +12,7 @@ class ExampleTest extends TestCase
      */
     public function test_the_application_returns_a_successful_response(): void
     {
-        $response = $this->get('/');
+        $response = $this->get('/login');
 
         $response->assertStatus(200);
     }

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -28,7 +28,8 @@ class ProfileTest extends TestCase
         $response = $this
             ->actingAs($user)
             ->patch('/profile', [
-                'name' => 'Test User',
+                'first_name' => 'Test',
+                'last_name' => 'User',
                 'email' => 'test@example.com',
             ]);
 
@@ -38,7 +39,8 @@ class ProfileTest extends TestCase
 
         $user->refresh();
 
-        $this->assertSame('Test User', $user->name);
+        $this->assertSame('Test', $user->first_name);
+        $this->assertSame('User', $user->last_name);
         $this->assertSame('test@example.com', $user->email);
         $this->assertNull($user->email_verified_at);
     }
@@ -50,7 +52,8 @@ class ProfileTest extends TestCase
         $response = $this
             ->actingAs($user)
             ->patch('/profile', [
-                'name' => 'Test User',
+                'first_name' => 'Test',
+                'last_name' => 'User',
                 'email' => $user->email,
             ]);
 
@@ -59,41 +62,5 @@ class ProfileTest extends TestCase
             ->assertRedirect('/profile');
 
         $this->assertNotNull($user->refresh()->email_verified_at);
-    }
-
-    public function test_user_can_delete_their_account(): void
-    {
-        $user = User::factory()->create();
-
-        $response = $this
-            ->actingAs($user)
-            ->delete('/profile', [
-                'password' => 'password',
-            ]);
-
-        $response
-            ->assertSessionHasNoErrors()
-            ->assertRedirect('/');
-
-        $this->assertGuest();
-        $this->assertNull($user->fresh());
-    }
-
-    public function test_correct_password_must_be_provided_to_delete_account(): void
-    {
-        $user = User::factory()->create();
-
-        $response = $this
-            ->actingAs($user)
-            ->from('/profile')
-            ->delete('/profile', [
-                'password' => 'wrong-password',
-            ]);
-
-        $response
-            ->assertSessionHasErrors('password')
-            ->assertRedirect('/profile');
-
-        $this->assertNotNull($user->fresh());
     }
 }


### PR DESCRIPTION
# Telemetry
With this change, it's possible to view existing telemetry within the application without having to dig into logs to trace an annoying issue
# Laboratory changes
- Apparently a user can be assigned to more than 1 laboratory, therefor it has been expanded that a user can have multiple laboratories
- This change also allows the migration of the values using the relevant migration table, so that existing users are properly set post change
- The column remains just in case, might be removed down the line
# Default system user
Useful for seeding and also default onboardings because it's important that a user is present for creations of other users
# Notifications
Templates themselves have been streamlined and improved handling of sending should one attempt fail